### PR TITLE
Issue2 provide freehand scissors tool with callback

### DIFF
--- a/src/tools/segmentation/FreehandScissorsTool.js
+++ b/src/tools/segmentation/FreehandScissorsTool.js
@@ -25,7 +25,7 @@ export default class FreehandScissorsTool extends BaseTool {
     const defaultProps = {
       name: 'FreehandScissors',
       strategies: {
-        FILL_INSIDE: fillInsideFreehand,
+        FILL_INSIDE: fillInsideFreehandScissors,
         FILL_OUTSIDE: fillOutsideFreehand,
         ERASE_OUTSIDE: eraseOutsideFreehand,
         ERASE_INSIDE: eraseInsideFreehand,
@@ -43,5 +43,17 @@ export default class FreehandScissorsTool extends BaseTool {
     };
 
     super(props, defaultProps);
+  }
+
+  setLabelmapChangeCallback(labelmapChangeCallback) {
+    this.labelmapChangeCallback = labelmapChangeCallback;
+  }
+}
+
+function fillInsideFreehandScissors(evt, operationData) {
+  fillInsideFreehand(evt, operationData);
+  const { element } = evt.detail;
+  if (this.labelmapChangeCallback) {
+    this.labelmapChangeCallback(element);
   }
 }

--- a/src/tools/segmentation/FreehandScissorsTool.js
+++ b/src/tools/segmentation/FreehandScissorsTool.js
@@ -26,32 +26,28 @@ export default class FreehandScissorsTool extends BaseTool {
       name: 'FreehandScissors',
       strategies: {
         FILL_INSIDE: (evt, operationData) =>
-          callStrategyWithLabelmapEvent(
+          this.callStrategyWithLabelmapEvent(
             evt,
             operationData,
-            fillInsideFreehand,
-            this.labelmapChangeCallback
+            fillInsideFreehand
           ),
         FILL_OUTSIDE: (evt, operationData) =>
-          callStrategyWithLabelmapEvent(
+          this.callStrategyWithLabelmapEvent(
             evt,
             operationData,
-            fillOutsideFreehand,
-            this.labelmapChangeCallback
+            fillOutsideFreehand
           ),
         ERASE_OUTSIDE: (evt, operationData) =>
-          callStrategyWithLabelmapEvent(
+          this.callStrategyWithLabelmapEvent(
             evt,
             operationData,
-            eraseOutsideFreehand,
-            this.labelmapChangeCallback
+            eraseOutsideFreehand
           ),
         ERASE_INSIDE: (evt, operationData) =>
-          callStrategyWithLabelmapEvent(
+          this.callStrategyWithLabelmapEvent(
             evt,
             operationData,
-            eraseInsideFreehand,
-            this.labelmapChangeCallback
+            eraseInsideFreehand
           ),
       },
       cursors: {
@@ -72,17 +68,12 @@ export default class FreehandScissorsTool extends BaseTool {
   setLabelmapChangeCallback(labelmapChangeCallback) {
     this.labelmapChangeCallback = labelmapChangeCallback;
   }
-}
 
-function callStrategyWithLabelmapEvent(
-  evt,
-  operationData,
-  freehandStrategyCallback,
-  labelmapChangeCallback
-) {
-  freehandStrategyCallback(evt, operationData);
-  const { element } = evt.detail;
-  if (labelmapChangeCallback) {
-    labelmapChangeCallback(element);
+  callStrategyWithLabelmapEvent(evt, operationData, freehandStrategyCallback) {
+    freehandStrategyCallback(evt, operationData);
+    const { element } = evt.detail;
+    if (this.labelmapChangeCallback) {
+      this.labelmapChangeCallback(element);
+    }
   }
 }

--- a/src/tools/segmentation/FreehandScissorsTool.js
+++ b/src/tools/segmentation/FreehandScissorsTool.js
@@ -25,10 +25,34 @@ export default class FreehandScissorsTool extends BaseTool {
     const defaultProps = {
       name: 'FreehandScissors',
       strategies: {
-        FILL_INSIDE: fillInsideFreehandScissors,
-        FILL_OUTSIDE: fillOutsideFreehand,
-        ERASE_OUTSIDE: eraseOutsideFreehand,
-        ERASE_INSIDE: eraseInsideFreehand,
+        FILL_INSIDE: (evt, operationData) =>
+          callStrategyWithLabelmapEvent(
+            evt,
+            operationData,
+            fillInsideFreehand,
+            this.labelmapChangeCallback
+          ),
+        FILL_OUTSIDE: (evt, operationData) =>
+          callStrategyWithLabelmapEvent(
+            evt,
+            operationData,
+            fillOutsideFreehand,
+            this.labelmapChangeCallback
+          ),
+        ERASE_OUTSIDE: (evt, operationData) =>
+          callStrategyWithLabelmapEvent(
+            evt,
+            operationData,
+            eraseOutsideFreehand,
+            this.labelmapChangeCallback
+          ),
+        ERASE_INSIDE: (evt, operationData) =>
+          callStrategyWithLabelmapEvent(
+            evt,
+            operationData,
+            eraseInsideFreehand,
+            this.labelmapChangeCallback
+          ),
       },
       cursors: {
         FILL_INSIDE: freehandFillInsideCursor,
@@ -50,10 +74,15 @@ export default class FreehandScissorsTool extends BaseTool {
   }
 }
 
-function fillInsideFreehandScissors(evt, operationData) {
-  fillInsideFreehand(evt, operationData);
+function callStrategyWithLabelmapEvent(
+  evt,
+  operationData,
+  freehandStrategyCallback,
+  labelmapChangeCallback
+) {
+  freehandStrategyCallback(evt, operationData);
   const { element } = evt.detail;
-  if (this.labelmapChangeCallback) {
-    this.labelmapChangeCallback(element);
+  if (labelmapChangeCallback) {
+    labelmapChangeCallback(element);
   }
 }

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '1.1.0';
+export default '1.1.1';


### PR DESCRIPTION
This PR allows a callback to be passed to the freehand scissors tool to be invoked when the tool modifies the labelmap. The callback itself can trigger an event to broadcast that the labelmap has changed.
