### PR TITLE
Issue4 change segment operations to bitwise

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@altis/cornerstone-tools",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Medical imaging tools for the Cornerstone library",
   "main": "./dist/cornerstoneTools.js",
   "publishConfig": {
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "build:altis": "npm run prepublishOnly && npm run copynota",
-    "copynota": "cp -a \"./dist/.\" \"../altis-labs/nota/packages/nota/node_modules/@altis/cornerstone-tools/dist\"",
+    "copynota": "cp -a \"./dist/.\" \"../../web-dev/packages/nota/node_modules/@altis/cornerstone-tools/dist\"",
     "watch:altis": "nodemon",
     "build": "npm run clean:dist && npm run version && npm run build:prod && npm run build:dev",
     "build:dev": "webpack --progress --config ./config/webpack/webpack-dev",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "build:altis": "npm run prepublishOnly && npm run copynota",
-    "copynota": "cp -a \"./dist/.\" \"../../web-dev/packages/nota/node_modules/@altis/cornerstone-tools/dist\"",
+    "copynota": "cp -a \"./dist/.\" \"../altis-labs/nota/packages/nota/node_modules/@altis/cornerstone-tools/dist\"",
     "watch:altis": "nodemon",
     "build": "npm run clean:dist && npm run version && npm run build:prod && npm run build:dev",
     "build:dev": "webpack --progress --config ./config/webpack/webpack-dev",

--- a/src/store/modules/segmentationModule/deleteAllLabelmaps.js
+++ b/src/store/modules/segmentationModule/deleteAllLabelmaps.js
@@ -1,0 +1,30 @@
+import getElement from './getElement';
+import { getToolState } from '../../../stateManagement/toolState.js';
+import state from './state';
+
+/**
+ *
+ * @param  {HTMLElement|string} elementOrEnabledElementUID The cornerstone
+ *                                            enabled element or its UUID.
+ * @returns {null}
+ */
+
+export default function deleteAllLabelmaps(elementOrEnabledElementUID) {
+  const element = getElement(elementOrEnabledElementUID);
+
+  if (!element) {
+    return;
+  }
+
+  const stackState = getToolState(element, 'stack');
+  const stackData = stackState.data[0];
+  const firstImageId = stackData.imageIds[0];
+
+  const brushStackState = state.series[firstImageId];
+
+  if (!brushStackState) {
+    return;
+  }
+
+  brushStackState.labelmaps3D = [];
+}

--- a/src/store/modules/segmentationModule/deleteLabelmap3D.js
+++ b/src/store/modules/segmentationModule/deleteLabelmap3D.js
@@ -35,12 +35,5 @@ export default function deleteLabelmap3D(
     return;
   }
 
-  brushStackState.labelmaps3D[labelmapIndex] = undefined;
-
-  if (brushStackState.labelmaps3D.length) {
-    let firstLabelmapIndex = brushStackState.labelmaps3D.findIndex(
-      element => element !== undefined
-    );
-    brushStackState.activeLabelmapIndex = firstLabelmapIndex;
-  }
+  brushStackState.labelmaps3D.splice(labelmapIndex, 1);
 }

--- a/src/store/modules/segmentationModule/deleteLabelmap3D.js
+++ b/src/store/modules/segmentationModule/deleteLabelmap3D.js
@@ -1,0 +1,39 @@
+import getElement from './getElement';
+import { getToolState } from '../../../stateManagement/toolState.js';
+import state from './state';
+
+/**
+ * Returns the index of the active `Labelmap3D`.
+ *
+ * @param  {HTMLElement|string} elementOrEnabledElementUID The cornerstone
+ *                                            enabled element or its UUID.
+ * @param labelmapIndex  The labelmapIndex to delete.
+ * @returns {null}
+ */
+
+export default function deleteLabelmap3D(
+  elementOrEnabledElementUID,
+  labelmapIndex
+) {
+  const element = getElement(elementOrEnabledElementUID);
+
+  if (!element) {
+    return;
+  }
+
+  const stackState = getToolState(element, 'stack');
+  const stackData = stackState.data[0];
+  const firstImageId = stackData.imageIds[0];
+
+  const brushStackState = state.series[firstImageId];
+
+  if (!brushStackState) {
+    return;
+  }
+
+  if (!brushStackState.labelmaps3D[labelmapIndex]) {
+    return;
+  }
+
+  brushStackState.labelmaps3D.splice(labelmapIndex, 1);
+}

--- a/src/store/modules/segmentationModule/deleteLabelmap3D.js
+++ b/src/store/modules/segmentationModule/deleteLabelmap3D.js
@@ -35,5 +35,12 @@ export default function deleteLabelmap3D(
     return;
   }
 
-  brushStackState.labelmaps3D.splice(labelmapIndex, 1);
+  brushStackState.labelmaps3D[labelmapIndex] = undefined;
+
+  if (brushStackState.labelmaps3D.length) {
+    let firstLabelmapIndex = brushStackState.labelmaps3D.findIndex(
+      element => element !== undefined
+    );
+    brushStackState.activeLabelmapIndex = firstLabelmapIndex;
+  }
 }

--- a/src/store/modules/segmentationModule/deleteSegment.js
+++ b/src/store/modules/segmentationModule/deleteSegment.js
@@ -66,14 +66,16 @@ export default function deleteSegment(
         segmentIndex
       );
 
-      labelmap2D.segmentsOnLabelmap.splice(indexOfSegment, 1);
+      console.log(pixelData);
 
+      labelmap2D.segmentsOnLabelmap.splice(indexOfSegment, 1);
       // Delete the label for this segment.
       for (let p = 0; p < pixelData.length; p++) {
-        if (pixelData[p] === segmentIndex) {
-          pixelData[p] = 0;
-        }
+        //if (pixelData[p] === segmentIndex) {
+        pixelData[p] = pixelData[p] & ~segmentIndex;
+        //}
       }
+      console.log(pixelData);
     }
   }
 

--- a/src/store/modules/segmentationModule/deleteSegment.js
+++ b/src/store/modules/segmentationModule/deleteSegment.js
@@ -66,16 +66,11 @@ export default function deleteSegment(
         segmentIndex
       );
 
-      console.log(pixelData);
-
       labelmap2D.segmentsOnLabelmap.splice(indexOfSegment, 1);
       // Delete the label for this segment.
       for (let p = 0; p < pixelData.length; p++) {
-        //if (pixelData[p] === segmentIndex) {
         pixelData[p] = pixelData[p] & ~segmentIndex;
-        //}
       }
-      console.log(pixelData);
     }
   }
 

--- a/src/store/modules/segmentationModule/index.js
+++ b/src/store/modules/segmentationModule/index.js
@@ -35,6 +35,7 @@ import getBrushColor from './getBrushColor';
 import getSegmentsOnPixelData from './getSegmentsOnPixeldata';
 import deleteSegment from './deleteSegment';
 import deleteLabelmap3D from './deleteLabelmap3D';
+import deleteAllLabelmaps from './deleteAllLabelmaps';
 
 import state from './state';
 import configuration from './defaultConfiguration';
@@ -126,6 +127,7 @@ export default {
     },
     deleteSegment,
     deleteLabelmap3D,
+    deleteAllLabelmaps,
     colorLUT: setColorLUT,
     colorLUTIndexForLabelmap3D: setColorLUTIndexForLabelmap3D,
     colorForSegmentIndexOfColorLUT: setColorForSegmentIndexOfColorLUT,

--- a/src/store/modules/segmentationModule/index.js
+++ b/src/store/modules/segmentationModule/index.js
@@ -34,6 +34,7 @@ import setColorLUT, {
 import getBrushColor from './getBrushColor';
 import getSegmentsOnPixelData from './getSegmentsOnPixeldata';
 import deleteSegment from './deleteSegment';
+import deleteLabelmap3D from './deleteLabelmap3D';
 
 import state from './state';
 import configuration from './defaultConfiguration';
@@ -124,6 +125,7 @@ export default {
       );
     },
     deleteSegment,
+    deleteLabelmap3D,
     colorLUT: setColorLUT,
     colorLUTIndexForLabelmap3D: setColorLUTIndexForLabelmap3D,
     colorForSegmentIndexOfColorLUT: setColorForSegmentIndexOfColorLUT,

--- a/src/util/segmentation/drawBrush.js
+++ b/src/util/segmentation/drawBrush.js
@@ -25,9 +25,11 @@ function drawBrushPixels(
     if (shouldErase) {
       eraseIfSegmentIndex(spIndex, pixelData, segmentIndex);
     } else {
-      pixelData[spIndex] = segmentIndex;
+      pixelData[spIndex] = pixelData[spIndex] | segmentIndex;
     }
   });
+
+  console.log(pixelData);
 }
 
 export { drawBrushPixels };

--- a/src/util/segmentation/drawBrush.js
+++ b/src/util/segmentation/drawBrush.js
@@ -28,8 +28,6 @@ function drawBrushPixels(
       pixelData[spIndex] = pixelData[spIndex] | segmentIndex;
     }
   });
-
-  console.log(pixelData);
 }
 
 export { drawBrushPixels };

--- a/src/util/segmentation/eraseIfSegmentIndex.js
+++ b/src/util/segmentation/eraseIfSegmentIndex.js
@@ -11,6 +11,6 @@ export default function eraseIfSegmentIndex(
   segmentIndex
 ) {
   if (pixelData[pixelIndex] === segmentIndex) {
-    pixelData[pixelIndex] = 0;
+    pixelData[pixelIndex] = pixelData[pixelIndex] & ~segmentIndex;
   }
 }

--- a/src/util/segmentation/fillShape.js
+++ b/src/util/segmentation/fillShape.js
@@ -52,7 +52,7 @@ function fillShape(
           y,
         })
       ) {
-        pixelData[pixelIndex] = segmentIndex;
+        pixelData[pixelIndex] = pixelData[pixelIndex] | segmentIndex;
       }
     }
   }


### PR DESCRIPTION
In this PR, labelmap segment operations are changed to be bitwise operations to support visible segment overlap. Functions were also added to delete labelmaps, as labelmaps will have to be created and deleted when segments are full. 
