### PR TITLE
Issue16 add ability to set brush radius

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@altis/cornerstone-tools",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Medical imaging tools for the Cornerstone library",
   "main": "./dist/cornerstoneTools.js",
   "publishConfig": {

--- a/src/store/modules/segmentationModule/index.js
+++ b/src/store/modules/segmentationModule/index.js
@@ -41,6 +41,8 @@ import state from './state';
 import configuration from './defaultConfiguration';
 import { pushState, undo, redo } from './history';
 import setRadius from './setRadius';
+import setMinRadius from './setMinRadius';
+import setMaxRadius from './setMaxRadius';
 
 /**
  * A map of `firstImageId` to associated `BrushStackState`, where
@@ -136,5 +138,7 @@ export default {
     pushState,
     undo,
     redo,
+    minRadius: setMinRadius,
+    maxRadius: setMaxRadius,
   },
 };

--- a/src/store/modules/segmentationModule/setMaxRadius.js
+++ b/src/store/modules/segmentationModule/setMaxRadius.js
@@ -1,0 +1,7 @@
+import { getModule } from '../../index';
+
+export default function setMaxRadius(newMaxRadius) {
+  const { configuration } = getModule('segmentation');
+
+  configuration.maxRadius = newMaxRadius;
+}

--- a/src/store/modules/segmentationModule/setMinRadius.js
+++ b/src/store/modules/segmentationModule/setMinRadius.js
@@ -1,0 +1,7 @@
+import { getModule } from '../../index';
+
+export default function setMinRadius(newMinRadius) {
+  const { configuration } = getModule('segmentation');
+
+  configuration.minRadius = newMinRadius;
+}

--- a/src/tools/base/BaseBrushTool.js
+++ b/src/tools/base/BaseBrushTool.js
@@ -318,7 +318,7 @@ class BaseBrushTool extends BaseTool {
    *
    * @public
    * @api
-   * @returns {void}
+   * @returns {radius}
    */
   increaseBrushSize() {
     const { configuration, setters } = segmentationModule;
@@ -332,6 +332,7 @@ class BaseBrushTool extends BaseTool {
     }
 
     setters.radius(newRadius);
+    return configuration.radius;
   }
 
   /**
@@ -339,7 +340,7 @@ class BaseBrushTool extends BaseTool {
    *
    * @public
    * @api
-   * @returns {void}
+   * @returns {radius}
    */
   decreaseBrushSize() {
     const { configuration, setters } = segmentationModule;
@@ -347,6 +348,25 @@ class BaseBrushTool extends BaseTool {
     const newRadius = Math.floor(oldRadius * 0.8);
 
     setters.radius(newRadius);
+    return configuration.radius;
+  }
+
+  setBrushSize(newRadius) {
+    const { setters } = segmentationModule;
+
+    setters.radius(newRadius);
+  }
+
+  setBrushMinSize(newMinRadius) {
+    const { setters } = segmentationModule;
+
+    setters.minRadius(newMinRadius);
+  }
+
+  setBrushMaxSize(newMaxRadius) {
+    const { setters } = segmentationModule;
+
+    setters.maxRadius(newMaxRadius);
   }
 
   _isCtrlDown(eventData) {


### PR DESCRIPTION
This PR adds the ability to set the brush radius through `BaseBrushTool` as well as it's minimum radius and maximum radius. I added this to be able to overwrite the `cornerstoneTools `default values through another application. 
