### PR TITLE
Fix copy/delete bug for contours

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "build:altis": "npm run prepublishOnly && npm run copynota",
-    "copynota": "cp -a \"./dist/.\" \"../altis-labs/nota/packages/nota/node_modules/@altis-labs/cornerstone-tools/dist\"",
+    "copynota": "cp -a \"./dist/.\" \"../nota/node_modules/@altis-labs/cornerstone-tools/dist\"",
     "watch:altis": "nodemon",
     "build": "npm run clean:dist && npm run version && npm run build:prod && npm run build:dev",
     "build:dev": "webpack --progress --config ./config/webpack/webpack-dev",

--- a/src/eventDispatchers/mouseEventHandlers/mouseDown.js
+++ b/src/eventDispatchers/mouseEventHandlers/mouseDown.js
@@ -90,18 +90,17 @@ export default function(evt) {
     const firstToolWithMoveableHandles = annotationToolsWithMoveableHandles[0];
     let toolState = getToolState(element, firstToolWithMoveableHandles.name);
 
-    // create a deep copy of toolState to avoid bad renders of contours after right clicks
-    toolState = JSON.parse(JSON.stringify(toolState));
+    if (firstToolWithMoveableHandles.roi) {
+      const activeRoiId = firstToolWithMoveableHandles.roi.id;
+      let temporaryValue;
 
-    const activeRoiId = firstToolWithMoveableHandles.roi.id;
-    let temporaryValue;
-
-    // Moves the elements with a roi id equal to the activeRoiId to the beginning of the toolState array
-    for (let i = 0; i < toolState.data.length; i++) {
-      if (toolState.data[i].roi.id === activeRoiId) {
-        temporaryValue = toolState.data[i];
-        toolState.data.splice(i, 1);
-        toolState.data.unshift(temporaryValue);
+      // Moves the elements with a roi id equal to the activeRoiId to the beginning of the toolState array
+      for (let i = 0; i < toolState.data.length; i++) {
+        if (toolState.data[i].roi.id === activeRoiId) {
+          temporaryValue = toolState.data[i];
+          toolState.data.splice(i, 1);
+          toolState.data.unshift(temporaryValue);
+        }
       }
     }
 

--- a/src/eventDispatchers/mouseEventHandlers/mouseDown.js
+++ b/src/eventDispatchers/mouseEventHandlers/mouseDown.js
@@ -88,7 +88,22 @@ export default function(evt) {
 
   if (annotationToolsWithMoveableHandles.length > 0) {
     const firstToolWithMoveableHandles = annotationToolsWithMoveableHandles[0];
-    const toolState = getToolState(element, firstToolWithMoveableHandles.name);
+    let toolState = getToolState(element, firstToolWithMoveableHandles.name);
+
+    // create a deep copy of toolState to avoid bad renders of contours after right clicks
+    toolState = JSON.parse(JSON.stringify(toolState));
+
+    const activeRoiId = firstToolWithMoveableHandles.roi.id;
+    let temporaryValue;
+
+    // Moves the elements with a roi id equal to the activeRoiId to the beginning of the toolState array
+    for (let i = 0; i < toolState.data.length; i++) {
+      if (toolState.data[i].roi.id === activeRoiId) {
+        temporaryValue = toolState.data[i];
+        toolState.data.splice(i, 1);
+        toolState.data.unshift(temporaryValue);
+      }
+    }
 
     const { handle, data } = findHandleDataNearImagePoint(
       element,

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '1.1.9';
+export default '1.1.10';

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '1.1.10';
+export default '1.1.11';


### PR DESCRIPTION
Closes #21 

- The issue was that right clicking a contour at a part that was shared by another contour would not display the copy/delete options
- This issue was fixed by rearranging an array of 9 elements (containing handle data) so that the elements corresponding to the active contour were placed at the beginning
