### PR TITLE
Issue037 fix handle bug caused by read only

### DIFF
--- a/src/eventDispatchers/mouseEventHandlers/mouseDown.js
+++ b/src/eventDispatchers/mouseEventHandlers/mouseDown.js
@@ -85,10 +85,22 @@ export default function(evt) {
     coords,
     'mouse'
   );
+  const annotationToolsWithWriteableHandles = annotationToolsWithMoveableHandles.filter(
+    ({ name }) => {
+      const toolState = getToolState(element, name);
+      const { data } = findHandleDataNearImagePoint(
+        element,
+        toolState,
+        name,
+        coords
+      );
+      return !data.readOnly;
+    }
+  );
 
-  if (annotationToolsWithMoveableHandles.length > 0) {
-    const firstToolWithMoveableHandles = annotationToolsWithMoveableHandles[0];
-    let toolState = getToolState(element, firstToolWithMoveableHandles.name);
+  if (annotationToolsWithWriteableHandles.length > 0) {
+    const firstToolWithMoveableHandles = annotationToolsWithWriteableHandles[0];
+    const toolState = getToolState(element, firstToolWithMoveableHandles.name);
 
     if (firstToolWithMoveableHandles.roi) {
       const activeRoiId = firstToolWithMoveableHandles.roi.id;


### PR DESCRIPTION
This PR fixes a handle bug caused by read only when multiple handles are on top of each other and the first one selected is `readOnly`. Handles with `readOnly` are filtered out before the first handle is selected.